### PR TITLE
Add oriented principal axis support in contour signatures

### DIFF
--- a/src/editor_tif/domain/models/contours.py
+++ b/src/editor_tif/domain/models/contours.py
@@ -15,3 +15,4 @@ class Contour:
     height: float     # alto del bbox (px)
     angle_deg: float  # ángulo principal (grados, antihorario)
     polygon: Optional[List[Tuple[float, float]]] = None  # opcional: lista de puntos (px)
+    principal_axis: Optional[Tuple[float, float]] = None  # vector unitario del eje mayor (px)

--- a/src/editor_tif/presentation/controllers/main_actions.py
+++ b/src/editor_tif/presentation/controllers/main_actions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import math
 from pathlib import Path
 from typing import Optional, Iterable
 
@@ -422,13 +423,23 @@ class MainActions:
                         for (x, y) in ct.polygon
                     ]
 
+                principal_axis = None
+                if getattr(ct, "principal_axis", None):
+                    ax, ay = ct.principal_axis
+                    ax_scene = float(ax) * sx
+                    ay_scene = float(ay) * sy
+                    norm = math.hypot(ax_scene, ay_scene)
+                    if norm > 1e-9:
+                        principal_axis = (ax_scene / norm, ay_scene / norm)
+
                 sig = ContourSignature(
                     cx=float(p_scene.x()),
                     cy=float(p_scene.y()),
                     width=w_scene,
                     height=h_scene,
                     angle_deg=float(ct.angle_deg),
-                    polygon=poly_scene
+                    polygon=poly_scene,
+                    principal_axis=principal_axis,
                 )
                 item = ContourItem()
                 item.set_from_signature(sig)

--- a/src/editor_tif/presentation/views/scene_items.py
+++ b/src/editor_tif/presentation/views/scene_items.py
@@ -213,21 +213,33 @@ class CentroidItem(QGraphicsEllipseItem):
         self._bbox_w: float = float(bbox_width)
         self._bbox_h: float = float(bbox_height)
         self._angle_deg: float = float(angle_deg)
+        self._principal_axis: Optional[Tuple[float, float]] = None
 
     # ---- Helpers geométricos ----
     def center_scene_pos(self) -> QPointF:
         """Devuelve la posición del centroide en coordenadas de escena."""
         return self.scenePos()
 
-    def set_signature(self, *, bbox_width: float, bbox_height: float, angle_deg: float) -> None:
+    def set_signature(
+        self,
+        *,
+        bbox_width: float,
+        bbox_height: float,
+        angle_deg: float,
+        principal_axis: Optional[Tuple[float, float]] = None,
+    ) -> None:
         """Actualiza ancho/alto del bbox y ángulo del contorno asociado."""
         self._bbox_w = float(bbox_width)
         self._bbox_h = float(bbox_height)
         self._angle_deg = float(angle_deg)
+        if principal_axis is None:
+            self._principal_axis = None
+        else:
+            self._principal_axis = (float(principal_axis[0]), float(principal_axis[1]))
 
-    def get_signature(self) -> Tuple[float, float, float]:
-        """Obtiene (bbox_width, bbox_height, angle_deg)."""
-        return self._bbox_w, self._bbox_h, self._angle_deg
+    def get_signature(self) -> Tuple[float, float, float, Optional[Tuple[float, float]]]:
+        """Obtiene (bbox_width, bbox_height, angle_deg, principal_axis)."""
+        return self._bbox_w, self._bbox_h, self._angle_deg, self._principal_axis
 
     # ---- Export directo a dominio ----
     def to_contour_signature(self) -> ContourSignature:
@@ -243,6 +255,7 @@ class CentroidItem(QGraphicsEllipseItem):
             width=self._bbox_w,
             height=self._bbox_h,
             angle_deg=self._angle_deg,
+            principal_axis=self._principal_axis,
         )
 
 


### PR DESCRIPTION
## Summary
- add an optional principal axis vector to `ContourSignature` and propagate it through scene items and template logic
- compute the directed major axis via PCA during contour detection and use it for placement/rotation calculations with fallbacks
- update serialization helpers to remain compatible with existing templates lacking the new field

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d6b49596b4832e8faa0ad554195d95