### PR TITLE
Skip template overlay layers when exporting

### DIFF
--- a/src/editor_tif/presentation/views/scene_items.py
+++ b/src/editor_tif/presentation/views/scene_items.py
@@ -43,6 +43,9 @@ class Layer:
     # Identificador lógico (para copiar/pegar)
     source_id: Optional[str] = None
 
+    # Marcadores internos
+    is_template_overlay: bool = False
+
 
 # =========================
 #   EVENTS


### PR DESCRIPTION
## Summary
- add an `is_template_overlay` flag to layers and mark template image overlays when groups are created, clearing the flag when the group is removed or made editable
- ignore template overlay layers when rasterizing or saving so only real clones are exported

## Testing
- python -m compileall src

------
https://chatgpt.com/codex/tasks/task_e_68d6bc033810832e961b13cde8d5f7e4