### PR TITLE
Handle PySide6 memoryview buffers in qimage_to_numpy

### DIFF
--- a/tests/test_qt_image.py
+++ b/tests/test_qt_image.py
@@ -1,0 +1,27 @@
+import os
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+import numpy as np
+import pytest
+
+pytest.importorskip("PySide6")
+pytest.importorskip("PySide6.QtGui")
+
+from PySide6.QtGui import QImage, qRgba
+
+from src.editor_tif.infrastructure.qt_image import qimage_to_numpy
+
+
+def test_qimage_to_numpy_handles_memoryview_bits():
+    width, height = 3, 2
+    image = QImage(width, height, QImage.Format_RGBA8888)
+    image.fill(qRgba(10, 20, 30, 40))
+
+    result = qimage_to_numpy(image)
+
+    assert result.shape == (height, width, 4)
+    assert result.dtype == np.uint8
+    # Ensure the color matches the fill value to confirm data integrity.
+    expected_pixel = np.array([10, 20, 30, 40], dtype=np.uint8)
+    assert np.all(result[0, 0] == expected_pixel)


### PR DESCRIPTION
## Summary
- update `qimage_to_numpy` to support both legacy pointers and memoryview buffers returned by `QImage.bits()`
- add a unit test ensuring conversion works for PySide6 6.9.x images

## Testing
- pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68dd5109c644832e8b982cd7e29ab495