### PR TITLE
Add affine template placement using min area rect vertices

### DIFF
--- a/src/editor_tif/domain/models/template.py
+++ b/src/editor_tif/domain/models/template.py
@@ -133,13 +133,33 @@ class Placement:
     scale_y: float
     piv_x: float
     piv_y: float
+    matrix: Optional[Tuple[Tuple[float, float, float], Tuple[float, float, float]]] = None
 
     def to_dict(self) -> Dict[str, Any]:
-        return asdict(self)
+        data = asdict(self)
+        return data
 
     @staticmethod
     def from_dict(data: Dict[str, Any]) -> "Placement":
-        return Placement(**data)
+        matrix = data.get("matrix")
+        if matrix is not None:
+            try:
+                matrix = (
+                    (float(matrix[0][0]), float(matrix[0][1]), float(matrix[0][2])),
+                    (float(matrix[1][0]), float(matrix[1][1]), float(matrix[1][2])),
+                )
+            except (TypeError, ValueError, IndexError):
+                matrix = None
+        return Placement(
+            tx=float(data["tx"]),
+            ty=float(data["ty"]),
+            rotation_deg=float(data["rotation_deg"]),
+            scale_x=float(data["scale_x"]),
+            scale_y=float(data["scale_y"]),
+            piv_x=float(data["piv_x"]),
+            piv_y=float(data["piv_y"]),
+            matrix=matrix,
+        )
 
 
 @dataclass

--- a/src/editor_tif/domain/services/placement.py
+++ b/src/editor_tif/domain/services/placement.py
@@ -1,7 +1,7 @@
 # src/editor_tif/domain/services/placement.py
 from __future__ import annotations
 
-from typing import Sequence, Tuple, List, Callable, Optional
+from typing import Sequence, Tuple, List, Callable, Optional, Iterable
 import math
 
 import cv2
@@ -9,6 +9,7 @@ import numpy as np
 
 from PySide6.QtWidgets import QGraphicsItem, QGraphicsPixmapItem, QGraphicsScene
 from PySide6.QtCore import QPointF
+from PySide6.QtGui import QTransform
 
 # Vista/UI
 from editor_tif.presentation.views.scene_items import CentroidItem, ImageItem, Layer
@@ -30,6 +31,36 @@ from editor_tif.domain.models.template import (
 Centroid = Tuple[float, float]
 
 
+def _order_box_points(points: Iterable[Tuple[float, float]]) -> List[Tuple[float, float]]:
+    pts = np.array(list(points), dtype=np.float32)
+    if pts.shape != (4, 2):
+        return [(float(p[0]), float(p[1])) for p in pts]
+
+    s = pts.sum(axis=1)
+    diff = np.diff(pts, axis=1)
+
+    ordered = [None] * 4
+    ordered[0] = pts[np.argmin(s)]  # top-left
+    ordered[2] = pts[np.argmax(s)]  # bottom-right
+    ordered[1] = pts[np.argmin(diff)]  # top-right
+    ordered[3] = pts[np.argmax(diff)]  # bottom-left
+
+    return [(float(p[0]), float(p[1])) for p in ordered]
+
+
+def _matrix_to_tuple(matrix: np.ndarray) -> Tuple[Tuple[float, float, float], Tuple[float, float, float]]:
+    return (
+        (float(matrix[0, 0]), float(matrix[0, 1]), float(matrix[0, 2])),
+        (float(matrix[1, 0]), float(matrix[1, 1]), float(matrix[1, 2])),
+    )
+
+
+def _matrix_to_qtransform(matrix: np.ndarray) -> QTransform:
+    a, b, tx = matrix[0]
+    c, d, ty = matrix[1]
+    return QTransform(float(a), float(c), 0.0, float(b), float(d), 0.0, float(tx), float(ty), 1.0)
+
+
 # =========================================================
 # Colocación desde PLANTILLA (sin escalado, centro como ancla)
 # =========================================================
@@ -41,6 +72,96 @@ def _clamp01_pair(v) -> Tuple[float, float]:
         return x, y
     except Exception:
         return 0.5, 0.5
+
+
+def get_item_min_area_rect_local_vertices(
+    item: ImageItem,
+    *,
+    threshold: int = 127,
+    min_area: float = 100.0,
+) -> Optional[dict]:
+    """Calcula los vértices del minAreaRect del contenido del item en coords locales.
+
+    Devuelve un diccionario serializable con ``vertices`` (orden TL, TR, BR, BL),
+    ``center`` (en coords locales), ``size`` y ``angle``. Si no se puede estimar,
+    retorna ``None``.
+    """
+
+    pixmap = item.pixmap()
+    if pixmap.isNull():
+        return None
+
+    image = pixmap.toImage()
+    array = qimage_to_numpy(image)
+
+    if array.ndim == 3:
+        channels = array.shape[2]
+        if channels >= 4:
+            gray = cv2.cvtColor(array, cv2.COLOR_RGBA2GRAY)
+        elif channels == 3:
+            gray = cv2.cvtColor(array, cv2.COLOR_RGB2GRAY)
+        else:
+            gray = array[..., 0]
+    else:
+        gray = array.astype(np.uint8)
+
+    gray = np.ascontiguousarray(gray)
+
+    if threshold is None or threshold < 0:
+        _, mask = cv2.threshold(gray, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
+    else:
+        _, mask = cv2.threshold(gray, int(threshold), 255, cv2.THRESH_BINARY)
+
+    contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    if not contours:
+        return None
+
+    largest = max(contours, key=cv2.contourArea)
+    area = cv2.contourArea(largest)
+    if area < float(min_area):
+        return None
+
+    rect = cv2.minAreaRect(largest)
+    box = cv2.boxPoints(rect)
+    ordered = _order_box_points(box)
+
+    offset = item.offset()
+    off_x = float(offset.x())
+    off_y = float(offset.y())
+
+    vertices_local = [(x + off_x, y + off_y) for x, y in ordered]
+    center_local = (float(rect[0][0]) + off_x, float(rect[0][1]) + off_y)
+    size = (float(rect[1][0]), float(rect[1][1]))
+    angle = float(rect[2])
+
+    return {
+        "vertices": [[float(x), float(y)] for x, y in vertices_local],
+        "center": [float(center_local[0]), float(center_local[1])],
+        "size": [float(size[0]), float(size[1])],
+        "angle": angle,
+    }
+
+
+def get_signature_box_vertices(signature: ContourSignature) -> List[Tuple[float, float]]:
+    """Devuelve los vértices ordenados (TL,TR,BR,BL) del rect destino en escena."""
+
+    if signature.polygon:
+        try:
+            pts = np.array(signature.polygon, dtype=np.float32)
+            if pts.ndim == 2:
+                pts = pts.reshape((-1, 1, 2))
+            rect = cv2.minAreaRect(pts)
+            box = cv2.boxPoints(rect)
+        except (cv2.error, ValueError, TypeError):
+            box = None
+    else:
+        box = None
+
+    if box is None:
+        rect = ((float(signature.cx), float(signature.cy)), (float(signature.width), float(signature.height)), float(signature.angle_deg))
+        box = cv2.boxPoints(rect)
+
+    return _order_box_points(box)
 
 
 def placement_from_template(
@@ -60,31 +181,102 @@ def placement_from_template(
     """
     rule: PlacementRule = template.rule
 
-    # 1) Sin escalado
-    sx = sy = 1.0
+    rect_meta = template.meta.get("item_min_area_rect") if isinstance(template.meta, dict) else None
+    src_vertices: Optional[List[Tuple[float, float]]] = None
+    if isinstance(rect_meta, dict):
+        verts = rect_meta.get("vertices")
+        if isinstance(verts, list) and len(verts) >= 4:
+            try:
+                src_vertices = [
+                    (float(v[0]), float(v[1]))
+                    for v in verts
+                ][:4]
+            except (TypeError, ValueError, IndexError):
+                src_vertices = None
 
-    # 2) Offset normalizado (en marco del bbox del contorno base) -> clamp y usar como relación
+    if src_vertices is None:
+        # Fallback: usar bbox centrado en el origen local
+        w = float(template.item_original_size[0])
+        h = float(template.item_original_size[1])
+        half_w = w / 2.0
+        half_h = h / 2.0
+        src_vertices = [
+            (-half_w, -half_h),
+            (half_w, -half_h),
+            (half_w, half_h),
+            (-half_w, half_h),
+        ]
+
+    dst_vertices = get_signature_box_vertices(target)
+    dst_vertices_np = np.array(dst_vertices, dtype=np.float32) if dst_vertices else np.zeros((0, 2), dtype=np.float32)
+
     off_xn, off_yn = _clamp01_pair(getattr(rule, "offset_norm", (0.5, 0.5)))
-
     base_angle_deg = float(target.angle_deg)
-
-    # 4) Rotación final
-    rot = (base_angle_deg + float(getattr(rule, "rotation_offset_deg", 0.0)))
     angle_rad = math.radians(base_angle_deg)
-    # 5) Offset local destino (marco del bbox destino, sin rotar)
-    #    (0.5,0.5) significa el centro del bbox -> delta (0,0)
     dx_local = (off_xn - 0.5) * target.width
     dy_local = (off_yn - 0.5) * target.height
-
-    # 6) Convertir delta_local al marco de ESCENA usando la orientación del contorno
     dx_scene = math.cos(angle_rad) * dx_local - math.sin(angle_rad) * dy_local
     dy_scene = math.sin(angle_rad) * dx_local + math.cos(angle_rad) * dy_local
+    dest_center = np.array([float(target.cx + dx_scene), float(target.cy + dy_scene)], dtype=np.float32)
 
-    # 7) Posición final del CENTRO del ítem
-    tx = target.cx + dx_scene
-    ty = target.cy + dy_scene
+    if dst_vertices_np.size == 0:
+        dst_vertices_np = np.array([
+            dest_center + [-0.5, -0.5],
+            dest_center + [0.5, -0.5],
+            dest_center + [0.5, 0.5],
+            dest_center + [-0.5, 0.5],
+        ], dtype=np.float32)
 
-    return Placement(tx=tx, ty=ty, rotation_deg=rot, scale_x=sx, scale_y=sy, piv_x=target.cx, piv_y=target.cy)
+    center_current = dst_vertices_np.mean(axis=0)
+    dst_vertices_np += (dest_center - center_current)
+
+    rotation_offset_deg = float(getattr(rule, "rotation_offset_deg", 0.0))
+    if rotation_offset_deg:
+        rot_rad = math.radians(rotation_offset_deg)
+        cos_r = math.cos(rot_rad)
+        sin_r = math.sin(rot_rad)
+        rot_mat = np.array([[cos_r, -sin_r], [sin_r, cos_r]], dtype=np.float32)
+        dst_vertices_np = ((dst_vertices_np - dest_center) @ rot_mat.T) + dest_center
+
+    dst_vertices = [tuple(map(float, pt)) for pt in dst_vertices_np]
+
+    matrix = None
+    if len(src_vertices) >= 3 and len(dst_vertices) >= 3:
+        src_pts = np.array(src_vertices[:3], dtype=np.float32)
+        dst_pts = np.array(dst_vertices[:3], dtype=np.float32)
+        try:
+            matrix = cv2.getAffineTransform(src_pts, dst_pts)
+        except cv2.error:
+            matrix = None
+
+    tx = float(dest_center[0])
+    ty = float(dest_center[1])
+    rot = float(base_angle_deg + rotation_offset_deg)
+    sx = sy = 1.0
+
+    if matrix is None:
+        # Fallback al comportamiento previo
+        tx = float(dest_center[0])
+        ty = float(dest_center[1])
+    else:
+        tx = float(matrix[0, 2])
+        ty = float(matrix[1, 2])
+        rot = math.degrees(math.atan2(matrix[1, 0], matrix[0, 0]))
+        sx = math.hypot(matrix[0, 0], matrix[1, 0])
+        sy = math.hypot(matrix[0, 1], matrix[1, 1])
+
+    matrix_tuple = _matrix_to_tuple(matrix) if matrix is not None else None
+
+    return Placement(
+        tx=tx,
+        ty=ty,
+        rotation_deg=rot,
+        scale_x=sx,
+        scale_y=sy,
+        piv_x=float(dest_center[0]),
+        piv_y=float(dest_center[1]),
+        matrix=matrix_tuple,
+    )
 
 
 # =========================================================
@@ -174,73 +366,65 @@ def apply_placement_to_item(
     item: ImageItem,
     placement: Placement,
 ) -> None:
-    """
-    Aplica Placement a un ImageItem respetando el pivote del contorno detectado.
-    - El pivote en escena (placement.piv_x, placement.piv_y) se mapea al marco local
-      del ítem y se usa como origen de transformación.
-    - El offset local se ajusta para que setPos(tx, ty) sitúe dicho pivote sobre el
-      centroide objetivo.
-    - Sin escalado (1.0).
-    """
-    #br = item.boundingRect()
-    #item.setTransformOriginPoint(br.center())
-    #item.setOffset(-br.width() / 2.0, -br.height() / 2.0)
+    """Aplica el Placement calculado al item y sincroniza el Layer asociado."""
 
-    centroide, pos, angle = get_item_min_area_rect(item)
-    pivot_scene = QPointF(centroide[0], centroide[1])
-    item.setTransformOriginPoint(pivot_scene)
-
-    current_offset = item.offset()
-    pivot_relative = pivot_scene - current_offset
-    item.setOffset(-pivot_relative.x(), -pivot_relative.y())
-    #pivot_scene = QPointF(float(getattr(placement, "piv_x", placement.tx)),
-    #                      float(getattr(placement, "piv_y", placement.ty)))
-#
-    #current_offset = item.offset()
-#
-    #try:
-    #    pivot_local = item.mapFromScene(pivot_scene)
-    #    pivot_relative = pivot_local - current_offset
-    #    if not (math.isfinite(pivot_relative.x()) and math.isfinite(pivot_relative.y())):
-    #        raise ValueError("invalid pivot coordinates")
-    #except Exception:
-    #    center_local = br.center()
-    #    pivot_relative = center_local - current_offset
-#
-    ## Ajustar el origen local del pixmap para que el pivote quede en (0,0)
-    #item.setOffset(-pivot_relative.x(), -pivot_relative.y())
-#
-    ## Con el pivote en (0,0), usarlo como origen de transformaciones
-    #item.setTransformOriginPoint(QPointF(0.0, 0.0))
-
-    # Sincronizar layer <-> item para que doc.save utilice la pose real
     layer = getattr(item, "layer", None)
     mm_to_scene = float(getattr(item, "mm_to_scene", 1.0) or 1.0)
 
-    if layer is not None:
-        layer.x = float(placement.tx) / mm_to_scene
-        layer.y = float(placement.ty) / mm_to_scene
-        layer.rotation = float(placement.rotation_deg)
+    matrix_data = getattr(placement, "matrix", None)
 
-        sx = float(placement.scale_x)
-        sy = float(placement.scale_y)
-        if math.isfinite(sx) and math.isfinite(sy):
-            if math.isclose(sx, sy, rel_tol=1e-6, abs_tol=1e-6):
+    if matrix_data is not None:
+        matrix_np = np.array(matrix_data, dtype=np.float64)
+        tx = float(matrix_np[0, 2])
+        ty = float(matrix_np[1, 2])
+        if layer is not None:
+            layer.transform_matrix = _matrix_to_tuple(matrix_np)
+            layer.x = tx / mm_to_scene
+            layer.y = ty / mm_to_scene
+            layer.rotation = float(placement.rotation_deg)
+            sx = float(placement.scale_x)
+            sy = float(placement.scale_y)
+            if math.isfinite(sx) and math.isfinite(sy):
+                if math.isclose(sx, sy, rel_tol=1e-6, abs_tol=1e-6):
+                    layer.scale = sx
+                else:
+                    layer.scale = (sx + sy) * 0.5
+            elif math.isfinite(sx):
                 layer.scale = sx
-            else:
-                layer.scale = (sx + sy) * 0.5
-        elif math.isfinite(sx):
-            layer.scale = sx
-        elif math.isfinite(sy):
-            layer.scale = sy
-
-    # Reflejar el estado del layer en el item
-    if hasattr(item, "sync_from_layer") and callable(item.sync_from_layer):
-        item.sync_from_layer()
+            elif math.isfinite(sy):
+                layer.scale = sy
+        if hasattr(item, "sync_from_layer") and callable(item.sync_from_layer) and layer is not None:
+            item.sync_from_layer()
+        else:
+            item.setTransformOriginPoint(QPointF(0.0, 0.0))
+            item.setPos(0.0, 0.0)
+            item.setTransform(_matrix_to_qtransform(matrix_np), False)
     else:
-        item.setRotation(placement.rotation_deg)
-        item.setScale(float(placement.scale_x))
-        item.setPos(QPointF(placement.tx, placement.ty))
+        if layer is not None:
+            layer.transform_matrix = None
+            layer.x = float(placement.tx) / mm_to_scene
+            layer.y = float(placement.ty) / mm_to_scene
+            layer.rotation = float(placement.rotation_deg)
+
+            sx = float(placement.scale_x)
+            sy = float(placement.scale_y)
+            if math.isfinite(sx) and math.isfinite(sy):
+                if math.isclose(sx, sy, rel_tol=1e-6, abs_tol=1e-6):
+                    layer.scale = sx
+                else:
+                    layer.scale = (sx + sy) * 0.5
+            elif math.isfinite(sx):
+                layer.scale = sx
+            elif math.isfinite(sy):
+                layer.scale = sy
+
+        if hasattr(item, "sync_from_layer") and callable(item.sync_from_layer) and layer is not None:
+            item.sync_from_layer()
+        else:
+            item.setTransformOriginPoint(QPointF(0.0, 0.0))
+            item.setRotation(placement.rotation_deg)
+            item.setScale(float(placement.scale_x))
+            item.setPos(QPointF(placement.tx, placement.ty))
 
     events = getattr(item, "events", None)
     committed = getattr(events, "committed", None)
@@ -401,10 +585,6 @@ def apply_template_over_scene_centroids(
         # 2) nuevo ImageItem
         item = ImageItem(layer, document=document, mm_to_scene=mm_to_scene)
         apply_placement_to_item(item, placement)
-
-        # Sincronizar layer.x/y (mm)
-        layer.x = item.pos().x() / mm_to_scene
-        layer.y = item.pos().y() / mm_to_scene
 
         scene.addItem(item)
         if bind_callback:

--- a/src/editor_tif/features/template_controller.py
+++ b/src/editor_tif/features/template_controller.py
@@ -29,6 +29,7 @@ from editor_tif.domain.models.template import (
 from editor_tif.domain.services.placement import (
     placement_from_template,
     apply_placement_to_item,
+    get_item_min_area_rect_local_vertices,
 )
 
 # Grupo visual (overlay de plantilla)
@@ -240,12 +241,18 @@ class TemplateController:
         # Tamaño original del ítem en unidades de escena (sólo informativo)
         iw_scene, ih_scene = self._item_size_scene_units(source_item)
 
+        rect_meta = get_item_min_area_rect_local_vertices(source_item)
+
+        meta = {"created_from": "controller.create_template"}
+        if rect_meta is not None:
+            meta["item_min_area_rect"] = rect_meta
+
         tpl = Template(
             item_source_id=source_item.source_id,
             item_original_size=(iw_scene, ih_scene),
             base_contour=base_signature,
             rule=measured_rule,
-            meta={"created_from": "controller.create_template"},
+            meta=meta,
         )
         self._templates.append(TemplateRecord(template=tpl, name=name))
         return tpl


### PR DESCRIPTION
## Summary
- capture item min-area-rectangle geometry when creating templates and store it in template metadata
- compute affine transforms from stored/template targets and apply them through layer-aware QTransform updates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd71891608832ea081721502886a3b