### PR TITLE
Add contour box vertices support

### DIFF
--- a/src/editor_tif/domain/models/contours.py
+++ b/src/editor_tif/domain/models/contours.py
@@ -15,4 +15,5 @@ class Contour:
     height: float     # alto del bbox (px)
     angle_deg: float  # ángulo principal (grados, antihorario)
     polygon: Optional[List[Tuple[float, float]]] = None  # opcional: lista de puntos (px)
+    box_vertices: Optional[List[Tuple[float, float]]] = None  # vertices del bbox rotado (px)
     principal_axis: Optional[Tuple[float, float]] = None  # vector unitario del eje mayor (px)

--- a/src/editor_tif/domain/models/template.py
+++ b/src/editor_tif/domain/models/template.py
@@ -39,6 +39,7 @@ class ContourSignature:
     height: float       # alto del bounding box del contorno
     angle_deg: float    # orientación principal del contorno (ej. eje mayor)
     polygon: Optional[List[Tuple[float, float]]] = None
+    box_vertices: Optional[List[Tuple[float, float]]] = None
     principal_axis: Optional[Tuple[float, float]] = None  # vector unitario del eje mayor (orientado)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -58,6 +59,15 @@ class ContourSignature:
                 data["principal_axis"] = [float(principal_axis[0]), float(principal_axis[1])]
             except (TypeError, ValueError, IndexError):
                 data["principal_axis"] = None
+        box_vertices = data.get("box_vertices")
+        if box_vertices is not None:
+            norm_box: List[List[float]] = []
+            for p in box_vertices:
+                if isinstance(p, (list, tuple)) and len(p) >= 2:
+                    norm_box.append([float(p[0]), float(p[1])])
+                elif hasattr(p, "x") and hasattr(p, "y"):
+                    norm_box.append([float(p.x()), float(p.y())])
+            data["box_vertices"] = norm_box if norm_box else None
         return data
 
     @staticmethod
@@ -81,6 +91,15 @@ class ContourSignature:
                 )
             except (TypeError, ValueError, IndexError):
                 parsed["principal_axis"] = None
+        box_vertices = parsed.get("box_vertices")
+        if box_vertices is not None:
+            norm_box = []
+            for p in box_vertices:
+                try:
+                    norm_box.append(tuple(float(coord) for coord in p[:2]))
+                except (TypeError, ValueError):
+                    continue
+            parsed["box_vertices"] = norm_box if norm_box else None
         return ContourSignature(**parsed)
 
 

--- a/src/editor_tif/presentation/controllers/main_actions.py
+++ b/src/editor_tif/presentation/controllers/main_actions.py
@@ -428,6 +428,15 @@ class MainActions:
                         for (x, y) in ct.polygon
                     ]
 
+                box_scene = None
+                if getattr(ct, "box_vertices", None):
+                    mapped = []
+                    for x, y in ct.box_vertices:
+                        p = self._bg_item.mapToScene(QPointF(float(x), float(y)))
+                        mapped.append((float(p.x()), float(p.y())))
+                    if mapped:
+                        box_scene = mapped
+
                 principal_axis = None
                 if getattr(ct, "principal_axis", None):
                     ax, ay = ct.principal_axis
@@ -444,6 +453,7 @@ class MainActions:
                     height=h_scene,
                     angle_deg=float(ct.angle_deg),
                     polygon=poly_scene,
+                    box_vertices=box_scene,
                     principal_axis=principal_axis,
                 )
                 item = ContourItem()


### PR DESCRIPTION
## Summary
- add optional rotated box vertices to contour detection and domain models
- propagate detector vertices to contour signatures, UI rendering, and placement helpers
- extend template serialization tests to cover the new contour data

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dd7931a92c832ebbaa9aae72773359