### PR TITLE
Capture template scene rect vertices for placement

### DIFF
--- a/src/editor_tif/features/template_controller.py
+++ b/src/editor_tif/features/template_controller.py
@@ -243,6 +243,23 @@ class TemplateController:
 
         rect_meta = get_item_min_area_rect_local_vertices(source_item)
 
+        if rect_meta is not None:
+            scene_vertices: Optional[list[list[float]]] = None
+            vertices_local = rect_meta.get("vertices") if isinstance(rect_meta, dict) else None
+            if isinstance(vertices_local, list) and len(vertices_local) >= 4:
+                scene_vertices = []
+                for vertex in vertices_local[:4]:
+                    try:
+                        vx = float(vertex[0])
+                        vy = float(vertex[1])
+                    except (TypeError, ValueError, IndexError):
+                        scene_vertices = None
+                        break
+                    point = source_item.mapToScene(QPointF(vx, vy))
+                    scene_vertices.append([float(point.x()), float(point.y())])
+            if scene_vertices:
+                rect_meta["scene_vertices"] = scene_vertices
+
         meta = {"created_from": "controller.create_template"}
         if rect_meta is not None:
             meta["item_min_area_rect"] = rect_meta


### PR DESCRIPTION
## Summary
- capture min-area rectangle vertices in scene coordinates when building template metadata
- use the stored scene-space vertices to define source points for affine estimation during placement

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ddc7a81910832ea75a6b2436cf780c